### PR TITLE
slave: Fix VhostUserConfig (un)marshalling

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -415,6 +415,8 @@ bitflags! {
     }
 }
 
+pub const VHOST_USER_MAX_CONFIG_SIZE: usize = 256;
+
 #[repr(packed)]
 #[derive(Default)]
 pub struct VhostUserConfig {
@@ -437,12 +439,7 @@ impl VhostUserMsgValidator for VhostUserConfig {
     fn is_valid(&self) -> bool {
         if (self.flags & !VhostUserConfigFlags::all().bits()) != 0 {
             return false;
-        } else if self.offset < VHOST_USER_CONFIG_OFFSET
-            || self.offset >= VHOST_USER_CONFIG_SIZE
-            || self.size == 0
-            || self.size > (VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET)
-            || self.size + self.offset > VHOST_USER_CONFIG_SIZE
-        {
+        } else if self.size > VHOST_USER_MAX_CONFIG_SIZE as u32 {
             return false;
         }
         true


### PR DESCRIPTION
The VhostUserConfig carries a message with a payload, the contents of
which depend on the kind of device being emulated.

With this change, we calculate the offset of the payload within the
message, check its size corresponds to the expected one, and pass it
to the backend as a generic pointer.

The backend will be responsible of validating the payload, as it's the
one aware of its expected contents.

Signed-off-by: Sergio Lopez <slp@redhat.com>